### PR TITLE
Improve Numigma page visual hierarchy

### DIFF
--- a/src/numigma/index.html
+++ b/src/numigma/index.html
@@ -14,17 +14,17 @@
         </script>
     </head>
 
-    <body class="bg-gray-50">
+    <body class="bg-gray-50 numigma-bg">
         <script type="module">
             import { createNavbar } from '@components/navbar.js';
             createNavbar();
         </script>
 
         <main
-            class="container mx-auto px-3 py-6 sm:px-4 sm:py-8 md:py-12 max-w-md md:max-w-3xl lg:max-w-5xl xl:max-w-6xl">
-            <div class="space-y-6 md:space-y-8">
+            class="numigma-layout container mx-auto px-3 py-6 sm:px-4 sm:py-8 md:py-12 max-w-md md:max-w-3xl lg:max-w-5xl xl:max-w-6xl">
+            <div class="space-y-8 md:space-y-10">
                 <section
-                    class="bg-gradient-to-br from-violet-600 via-indigo-500 to-blue-500 text-white rounded-3xl shadow-xl overflow-hidden">
+                    class="numigma-hero bg-gradient-to-br from-violet-600 via-indigo-500 to-blue-500 text-white rounded-3xl shadow-xl overflow-hidden">
                     <div class="p-6 sm:p-8 lg:p-10">
                         <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-6">
                             <div class="space-y-4 lg:max-w-2xl">
@@ -57,7 +57,7 @@
                             </div>
                             <div class="lg:self-start">
                                 <button id="generate-button"
-                                    class="inline-flex items-center justify-center gap-2 px-5 py-3 bg-white/95 text-indigo-600 font-semibold rounded-2xl shadow-lg shadow-indigo-900/20 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white transition-all">
+                                    class="numigma-hero-button inline-flex items-center justify-center gap-2 px-5 py-3 bg-white/95 text-indigo-600 font-semibold rounded-2xl shadow-lg shadow-indigo-900/20 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white transition-all">
                                     <i class="fas fa-dice"></i>
                                     Generate puzzle
                                 </button>
@@ -66,10 +66,45 @@
                     </div>
                 </section>
 
+                <section class="numigma-section numigma-step-panel bg-white numigma-surface">
+                    <div class="p-5 sm:p-6 lg:p-8 space-y-5">
+                        <div class="numigma-section-header space-y-2">
+                            <div class="numigma-section-kicker">Quick start</div>
+                            <h2 class="text-xl font-semibold text-gray-900">Find a puzzle flow in minutes</h2>
+                            <p class="text-sm text-gray-600">Use the generator controls and clue packs below, then hit
+                                generate to craft a unique logic puzzle with a shareable link.</p>
+                        </div>
+                        <div class="numigma-step-grid">
+                            <div class="numigma-step-card">
+                                <div class="numigma-step-number">1</div>
+                                <div>
+                                    <div class="numigma-step-title">Define the range</div>
+                                    <p>Set the minimum, maximum, and difficulty to bound the search.</p>
+                                </div>
+                            </div>
+                            <div class="numigma-step-card">
+                                <div class="numigma-step-number">2</div>
+                                <div>
+                                    <div class="numigma-step-title">Pick clue packs</div>
+                                    <p>Toggle mathematical themes to shape the logic flavor and tone.</p>
+                                </div>
+                            </div>
+                            <div class="numigma-step-card">
+                                <div class="numigma-step-number">3</div>
+                                <div>
+                                    <div class="numigma-step-title">Generate &amp; share</div>
+                                    <p>Review diagnostics, copy clues, and share the deterministic link.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
                 <section
-                    class="bg-white numigma-surface overflow-hidden divide-y divide-gray-100">
+                    class="numigma-section bg-white numigma-surface overflow-hidden divide-y divide-gray-100">
                     <div class="p-5 sm:p-6 lg:p-8 space-y-6">
-                        <div class="space-y-4">
+                        <div class="numigma-section-header space-y-3">
+                            <div class="numigma-section-kicker">Start here</div>
                             <h2 class="text-xl font-semibold text-gray-900 flex items-center gap-2">
                                 <i class="fas fa-tuning-fork text-indigo-500"></i>
                                 Generator controls
@@ -120,7 +155,7 @@
 
                     <div class="p-5 sm:p-6 lg:p-8 space-y-5" id="clue-pack-container">
                         <div class="flex flex-col md:flex-row md:items-center justify-between gap-4">
-                            <div class="space-y-2">
+                            <div class="numigma-section-header space-y-2">
                                 <h3 class="text-lg font-semibold text-gray-900">Clue packs</h3>
                                 <p class="text-sm text-gray-600">Toggle mathematical themes to shape the flavor of the
                                     generated puzzle.</p>
@@ -161,7 +196,7 @@
                     <div class="lg:col-span-3 space-y-6">
                         <div class="bg-white numigma-surface">
                             <div
-                                class="border-b border-gray-100 px-5 py-4 sm:px-6 flex items-center justify-between gap-3">
+                                class="numigma-section-header border-b border-gray-100 px-5 py-4 sm:px-6 flex items-center justify-between gap-3">
                                 <h3 class="text-lg font-semibold text-gray-900">Active clues</h3>
                                 <div class="flex items-center gap-3">
                                     <button id="copy-clues-button" class="copy-clues-button" type="button" disabled>
@@ -177,7 +212,7 @@
                         </div>
 
                         <div class="bg-white numigma-surface">
-                            <div class="border-b border-gray-100 px-5 py-4 sm:px-6">
+                            <div class="numigma-section-header border-b border-gray-100 px-5 py-4 sm:px-6">
                                 <h3 class="text-lg font-semibold text-gray-900">Candidate inspector</h3>
                             </div>
                             <div class="p-5 sm:p-6 space-y-4 text-sm text-gray-600" id="candidate-details">
@@ -189,7 +224,7 @@
                     <div class="lg:col-span-2 space-y-6">
                         <div class="bg-white numigma-surface">
                             <div
-                                class="border-b border-gray-100 px-5 py-4 sm:px-6 flex flex-wrap items-center justify-between gap-3">
+                                class="numigma-section-header border-b border-gray-100 px-5 py-4 sm:px-6 flex flex-wrap items-center justify-between gap-3">
                                 <h3 class="text-lg font-semibold text-gray-900">Puzzle diagnostics</h3>
                                 <div class="flex items-center gap-3">
                                     <span id="status-badge"
@@ -211,7 +246,7 @@
                         </div>
 
                         <div class="bg-white numigma-surface">
-                            <div class="border-b border-gray-100 px-5 py-4 sm:px-6 flex items-center justify-between">
+                            <div class="numigma-section-header border-b border-gray-100 px-5 py-4 sm:px-6 flex items-center justify-between">
                                 <h3 class="text-lg font-semibold text-gray-900">Solution reveal</h3>
                                 <button id="toggle-solution"
                                     class="text-sm font-semibold text-indigo-600 hover:text-indigo-700">Reveal</button>

--- a/src/numigma/styles.css
+++ b/src/numigma/styles.css
@@ -4,12 +4,38 @@
     --numigma-dark: 15 23 42;
 }
 
+.numigma-bg {
+    background: radial-gradient(circle at top, rgba(224, 231, 255, 0.6), transparent 45%),
+        #f8fafc;
+}
+
+.numigma-layout {
+    display: block;
+}
+
+.numigma-hero {
+    position: relative;
+}
+
+.numigma-hero::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at top right, rgba(255, 255, 255, 0.2), transparent 60%);
+    opacity: 0.9;
+    pointer-events: none;
+}
+
+.numigma-hero-button {
+    box-shadow: 0 18px 32px -20px rgba(15, 23, 42, 0.45);
+}
+
 .numigma-surface {
     position: relative;
     border-radius: 1.75rem;
     border: 1px solid rgba(var(--numigma-muted), 0.3);
-    box-shadow: 0 28px 60px -40px rgba(var(--numigma-dark), 0.55),
-        0 22px 48px -36px rgba(var(--numigma-primary), 0.45);
+    box-shadow: 0 20px 38px -34px rgba(var(--numigma-dark), 0.35),
+        0 16px 32px -30px rgba(var(--numigma-primary), 0.2);
     overflow: hidden;
 }
 
@@ -18,9 +44,70 @@
     position: absolute;
     inset: 0;
     border-radius: inherit;
-    background: linear-gradient(135deg, rgba(var(--numigma-primary), 0.08), transparent 55%);
+    background: linear-gradient(135deg, rgba(var(--numigma-primary), 0.05), transparent 60%);
     pointer-events: none;
-    opacity: 0.55;
+    opacity: 0.4;
+}
+
+.numigma-section-header {
+    position: relative;
+    z-index: 1;
+}
+
+.numigma-section-kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.2rem 0.65rem;
+    border-radius: 999px;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgb(var(--numigma-primary));
+    background: rgba(var(--numigma-primary), 0.12);
+    border: 1px solid rgba(var(--numigma-primary), 0.2);
+}
+
+.numigma-step-panel {
+    border-left: 4px solid rgba(var(--numigma-primary), 0.35);
+}
+
+.numigma-step-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.numigma-step-card {
+    display: flex;
+    gap: 0.9rem;
+    padding: 1rem 1.1rem;
+    border-radius: 1.25rem;
+    background: rgba(248, 250, 252, 0.95);
+    border: 1px solid rgba(var(--numigma-muted), 0.3);
+    box-shadow: 0 12px 24px -20px rgba(var(--numigma-dark), 0.25);
+    font-size: 0.85rem;
+    color: rgba(var(--numigma-dark), 0.68);
+}
+
+.numigma-step-number {
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    color: rgb(var(--numigma-primary));
+    background: rgba(var(--numigma-primary), 0.12);
+    border: 1px solid rgba(var(--numigma-primary), 0.25);
+}
+
+.numigma-step-title {
+    font-weight: 600;
+    color: rgb(var(--numigma-dark));
+    margin-bottom: 0.2rem;
 }
 
 .numigma-info-chip {
@@ -266,7 +353,7 @@
     position: relative;
     border-radius: 1.25rem;
     border: 1px solid rgba(var(--numigma-muted), 0.35);
-    background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 249, 0.95));
+    background: #fff;
     padding: 1.15rem;
     display: flex;
     gap: 0.75rem;
@@ -289,13 +376,13 @@
 .numigma-pack:hover {
     transform: translateY(-2px);
     border-color: rgba(var(--numigma-primary), 0.45);
-    box-shadow: 0 12px 30px -18px rgba(var(--numigma-primary), 0.8);
+    box-shadow: 0 16px 32px -24px rgba(var(--numigma-primary), 0.45);
 }
 
 .numigma-pack.is-active {
     border-color: rgba(var(--numigma-primary), 0.65);
-    box-shadow: 0 18px 38px -24px rgba(var(--numigma-primary), 0.75);
-    background: linear-gradient(135deg, rgba(224, 231, 255, 0.75), rgba(241, 245, 249, 0.95));
+    box-shadow: 0 18px 36px -28px rgba(var(--numigma-primary), 0.55);
+    background: rgba(224, 231, 255, 0.5);
 }
 
 .numigma-pack.is-active::before {
@@ -345,10 +432,9 @@
     position: relative;
     border-radius: 1.25rem;
     padding: 1rem 1.1rem 1.1rem;
-    background: radial-gradient(circle at top left, rgba(var(--numigma-primary), 0.08), transparent 60%),
-        #ffffff;
+    background: #ffffff;
     border: 1px solid rgba(var(--numigma-muted), 0.28);
-    box-shadow: 0 10px 28px -18px rgba(var(--numigma-primary), 0.8);
+    box-shadow: 0 12px 24px -20px rgba(var(--numigma-primary), 0.35);
     overflow: hidden;
     transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
@@ -369,7 +455,7 @@
 .clue-card:hover {
     transform: translateY(-2px);
     border-color: rgba(var(--numigma-primary), 0.5);
-    box-shadow: 0 22px 45px -26px rgba(var(--numigma-primary), 0.9);
+    box-shadow: 0 18px 36px -28px rgba(var(--numigma-primary), 0.6);
 }
 
 .clue-card:hover::after {


### PR DESCRIPTION
### Motivation
- The Numigma page is visually overwhelming on first load and lacks a clear entry path for new users. 
- Provide a calm, readable layout and clear affordances that guide people to the primary puzzle flow without removing features. 
- Improve perceived hierarchy so controls, clue packs, and results are easier to scan and act on.

### Description
- Add a `Quick start` step panel and section kickers in `src/numigma/index.html` to surface the primary 3-step flow (range → packs → generate). 
- Introduce structural classes (`numigma-bg`, `numigma-layout`, `numigma-hero`, `numigma-section-header`, `numigma-step-panel`, etc.) and a lightweight step card UI in `src/numigma/styles.css` to create visual anchors. 
- Soften visual noise by reducing heavy shadows and gradients, switching pack/clue card backgrounds to calmer fills, and adding subtle background accents to the hero and page. 
- Preserve existing functionality and markup for controls and JavaScript hooks (no behavioral changes to generator logic or event handlers). 

### Testing
- Launched the dev server with `npm run dev` and Vite reported ready on the configured port. 
- Attempted an automated Playwright screenshot that failed due to the headless Chromium process crashing (SIGSEGV), so no screenshot was produced. 
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696245af0898832e83ed3f643c12ed0f)